### PR TITLE
Heatmap Manual adjustment option on Streamlit.

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -223,8 +223,8 @@ def main():
         if not manualRange:
             color_range = score_range
         show_pred(sample, img_lvl_anom_score, pxl_lvl_anom_score, color_range)
-        st.write("pixcel score min:{:.0f}".format(score_range[0]))
-        st.write("pixcel score max:{:.0f}".format(score_range[1]))
+        st.write("pixel score min:{:.0f}".format(score_range[0]))
+        st.write("pixel score max:{:.0f}".format(score_range[1]))
 
 @contextmanager
 def st_redirect(src, dst, msg):


### PR DESCRIPTION
Thank you for sharing your streamlit code. 

It was very easy to check my  data.
![image](https://user-images.githubusercontent.com/50163300/132226201-d52a1ed6-8a0d-4134-96f3-d64ac348c798.png)

But I made a red pattern even in a normal image.
![image](https://user-images.githubusercontent.com/50163300/132226505-bb8c3433-aa50-4078-b4a4-b48786333e59.png)

Because on streamlit color assignment of heatmap is decided by each image.
I think it is better to fix the range if necessary.

So I made it.
If you don't check the box, the operation will be the same as before.
![image](https://user-images.githubusercontent.com/50163300/132225320-6b8925f2-4ae5-4311-a13f-40e16f8bc89e.png)

If you like it, please merge it.